### PR TITLE
Update links to GitHub repository in the docs

### DIFF
--- a/data-message/docs/0-status.md
+++ b/data-message/docs/0-status.md
@@ -4,12 +4,13 @@
 Other documents may supersede this document.*
 
 This is a SDMX Candidate Technical Standard for SDMX-JSON Data Message. It is
-made available for review by the SDMX user community and the public.
+made available for review by the SDMX user community and the public. The public 
+review period for this document extends until November 31 2015 in order to allow 
+time for implementation. 
 
-The public review period for this document extends until November 31 2015 in
-order to allow time for implementation. Please send your comments to the SDMX
-Technical Working Group (SDMX-TWG) <twg@sdmx.org>. Each email message should
-contain only one comment. All feedback is welcome.
+Please send your comments to the SDMX Technical Working Group (SDMX-TWG) <twg@sdmx.org>. 
+Each email message should contain only one comment. Pull request can also be be submitted to 
+the GitHub repository <https://github.com/sdmx-twg/sdmx-json>. All feedback is welcome. 
 
 Publication as a Candidate Technical Standard does not imply endorsement by the
 SDMX Sponsors. This is a draft document and may be updated, replaced or obsoleted by other

--- a/data-message/docs/1-sdmx-json-field-guide.md
+++ b/data-message/docs/1-sdmx-json-field-guide.md
@@ -27,7 +27,7 @@ however the above should be sufficient to understand the sdmx-json format. For
 additional information, please refer to the [SDMX documentation](http://sdmx.org/?page_id=10).
 
 Samples, tools and other SDMX-JSON resources are available in the public Github
-repository <https://github.com/sdmx-twg/sdmx-prototype-json/tree/master/draft-sdmx-json>.
+repository <https://github.com/sdmx-twg/sdmx-json>.
 
 Before we start, let's clarify a few more things about this guide:
 


### PR DESCRIPTION
Link to GitHub repository was missing from the document status and the link the intro was still pointing to the old prototype repository.

@sosna 