### PR TITLE
Standardize README and remove stale release version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ This includes:
 - Normative documentation and samples for the SDMX-JSON data message format
 - Normative documentation and samples for the SDMX-JSON metadata message format
 
-The current release version is SDMX-JSON 2.1.0
+The schemas are published to <https://json.sdmx.org>
 
-The schemas are published to https://json.sdmx.org
+## Repository Structure
+
+-   `docs/` — Markdown content pages for the SDMX-JSON specification.
+-   `mkdocs.yml` — MkDocs configuration integrating this component into the
+    `sdmx-docs` site.
+
+## Version Branches
+
+Each release of this component is maintained on a dedicated branch following the
+pattern `X.Y.x` (e.g., `2.1.x`). The branch tracked by the
+[`sdmx-docs`](https://github.com/sdmx-twg/sdmx-docs) parent repository is
+declared in `.gitmodules` at the root of that repo. Switching the tracked branch
+in the parent repository is how a new version of this component is published on
+the documentation site.
+
+## Formatting Conventions
+
+For Markdown and MkDocs formatting conventions that apply to content in `docs/`,
+see the [`sdmx-docs` README](https://github.com/sdmx-twg/sdmx-docs#readme).
+


### PR DESCRIPTION
Remove "The current release version is SDMX-JSON 2.1.0"; append Repository Structure, Version Branches, and Formatting Conventions sections to align with the shared submodule README template.